### PR TITLE
Extract Node Groups

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -77,6 +77,19 @@ func filterNodes[T TypedNode](c *Canvas) []T {
 	return nodes
 }
 
+func (c *Canvas) NodeGroup(n GroupNode) []TypedNode {
+	var nodes []TypedNode
+	for _, node := range c.Nodes {
+		if node.ToNode().ID == n.ID {
+			continue
+		}
+		if n.Contains(node.ToNode().BaseNode) {
+			nodes = append(nodes, node)
+		}
+	}
+	return nodes
+}
+
 func (c *Canvas) Validate() error {
 	if c == nil {
 		return nil

--- a/canvas_test.go
+++ b/canvas_test.go
@@ -25,6 +25,27 @@ func TestNodeFilters(t *testing.T) {
 	assert.ElementsMatch(t, texts, c.TextNodes())
 }
 
-func shuffle[T interface{}](slice []T) {
+func TestGroupedNodes(t *testing.T) {
+	groupNode := NewGroupNode("Group 1", nil, nil, Position(0, 0), Width(100), Height(100))
+	contained := []TypedNode{
+		NewTextNode("Text 1", Position(1, 1), Width(10), Height(10)),
+		NewTextNode("Text 2", Position(20, 1), Width(10), Height(10)),
+		NewTextNode("Text 3", Position(40, 1), Width(10), Height(10)),
+	}
+	rest := []TypedNode{
+		NewTextNode("Text 4", Position(-1, 1), Width(10), Height(10)),
+		NewTextNode("Text 5", Position(120, 1), Width(10), Height(10)),
+		NewTextNode("Text 6", Position(0, 0), Width(110), Height(10)),
+	}
+
+	nodes := slices.Concat([]TypedNode{groupNode}, contained, rest)
+	shuffle(nodes)
+
+	c := NewCanvas(WithNodes(nodes...))
+
+	assert.ElementsMatch(t, contained, c.NodeGroup(groupNode))
+}
+
+func shuffle[T any](slice []T) {
 	rand.Shuffle(len(slice), func(i, j int) { slice[i], slice[j] = slice[j], slice[i] })
 }

--- a/node.go
+++ b/node.go
@@ -17,6 +17,10 @@ type TypedNode interface {
 	Validate() error
 }
 
+type Container interface {
+	Contains(Container) bool
+}
+
 type BaseNode struct {
 	ID     string  `json:"id"`
 	Type   string  `json:"type"` // one of "text", "file", "link", "group"
@@ -25,6 +29,13 @@ type BaseNode struct {
 	Width  int     `json:"width"`
 	Height int     `json:"height"`
 	Color  *string `json:"color,omitempty"`
+}
+
+func (b BaseNode) Contains(n BaseNode) bool {
+	bdx, bdy := b.X + b.Width, b.Y + b.Height
+	ndx, ndy := n.X + n.Width, n.Y + n.Height
+
+	return n.X >= b.X && n.Y >= b.Y && ndx <= bdx && ndy <= bdy
 }
 
 type Node struct {

--- a/node_test.go
+++ b/node_test.go
@@ -176,6 +176,20 @@ func TestBaseNodeOpts(t *testing.T) {
 	assert.Equal(t, node.Height, 20)
 }
 
+func TestContains(t *testing.T) {
+	node1 := newBaseNode("text", Position(0, 0), Width(100), Height(100))
+	node2 := newBaseNode("text", Position(10, 10), Width(50), Height(50))
+	node3 := newBaseNode("text", Position(-10, 10), Width(50), Height(50))
+	node4 := newBaseNode("text", Position(10, 10), Width(150), Height(50))
+	node5 := newBaseNode("text", Position(110, 10), Width(50), Height(50))
+
+	assert.True(t, node1.Contains(node1))
+	assert.True(t, node1.Contains(node2))
+	assert.False(t, node1.Contains(node3))
+	assert.False(t, node1.Contains(node4))
+	assert.False(t, node1.Contains(node5))
+}
+
 func testBaseNode(t string) BaseNode {
 	return BaseNode{
 		ID:     t,


### PR DESCRIPTION
- Adds `NodeGroup` method to `Canvas` to retrieve all nodes contained in a `GroupNode`
- Add `Contains` method to `Node` to check if a `Node` is contained in another `Node`
