### PR TITLE
Add `ChildNodes` and `ParentNodes` to `Canvas`

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -90,6 +90,57 @@ func (c *Canvas) NodeGroup(n GroupNode) []TypedNode {
 	return nodes
 }
 
+func (c *Canvas) ChildNodes(n BaseNode) []TypedNode {
+	var nodes []TypedNode
+
+	fromEdges, _ := c.nodeEdges(n)
+
+	for _, edge := range fromEdges {
+		nodes = append(nodes, c.GetNodeById(edge.ToNode))
+	}
+
+	return nodes
+}
+
+func (c *Canvas) ParentNodes(n BaseNode) []TypedNode {
+	var nodes []TypedNode
+
+	_, toEdges := c.nodeEdges(n)
+
+	for _, edge := range toEdges {
+		nodes = append(nodes, c.GetNodeById(edge.FromNode))
+	}
+
+	return nodes
+}
+
+func (c *Canvas) nodeEdges(n BaseNode) ([]Edge, []Edge) {
+	var fromEdges []Edge
+	var toEdges []Edge
+
+	for _, edge := range c.Edges {
+		if edge.FromNode == n.ID {
+			fromEdges = append(fromEdges, edge)
+		}
+
+		if edge.ToNode == n.ID {
+			toEdges = append(toEdges, edge)
+		}
+	}
+
+	return fromEdges, toEdges
+}
+
+func (c *Canvas) GetNodeById(id string) TypedNode {
+	var node TypedNode
+	for _, n := range c.Nodes {
+		if n.ToNode().ID == id {
+			node = n
+		}
+	}
+	return node
+}
+
 func (c *Canvas) Validate() error {
 	if c == nil {
 		return nil

--- a/canvas_test.go
+++ b/canvas_test.go
@@ -46,6 +46,36 @@ func TestGroupedNodes(t *testing.T) {
 	assert.ElementsMatch(t, contained, c.NodeGroup(groupNode))
 }
 
+func TestChildNodes(t *testing.T) {
+	text1, text2, text3, text4 := NewTextNode("Text 1"), NewTextNode("Text 2"), NewTextNode("Text 3"), NewTextNode("Text 4")
+	edges := []Edge{
+		NewEdge(text1.ToNode(), text2.ToNode(), "right", "left"),
+		NewEdge(text1.ToNode(), text3.ToNode(), "right", "left"),
+		NewEdge(text3.ToNode(), text4.ToNode(), "right", "left"),
+	}
+	nodes := []TypedNode{text1, text2, text3, text4}
+
+	c := NewCanvas(WithNodes(nodes...), WithEdges(edges...))
+
+	assert.ElementsMatch(t, []TypedNode{text2, text3}, c.ChildNodes(text1.BaseNode))
+	assert.ElementsMatch(t, []TypedNode{text4}, c.ChildNodes(text3.BaseNode))
+}
+
+func TestParentNodes(t *testing.T) {
+	text1, text2, text3, text4 := NewTextNode("Text 1"), NewTextNode("Text 2"), NewTextNode("Text 3"), NewTextNode("Text 4")
+	edges := []Edge{
+		NewEdge(text1.ToNode(), text3.ToNode(), "right", "left"),
+		NewEdge(text2.ToNode(), text3.ToNode(), "right", "left"),
+		NewEdge(text3.ToNode(), text4.ToNode(), "right", "left"),
+	}
+	nodes := []TypedNode{text1, text2, text3, text4}
+
+	c := NewCanvas(WithNodes(nodes...), WithEdges(edges...))
+
+	assert.ElementsMatch(t, []TypedNode{text1, text2}, c.ParentNodes(text3.BaseNode))
+	assert.ElementsMatch(t, []TypedNode{text3}, c.ParentNodes(text4.BaseNode))
+}
+
 func shuffle[T any](slice []T) {
 	rand.Shuffle(len(slice), func(i, j int) { slice[i], slice[j] = slice[j], slice[i] })
 }

--- a/edge.go
+++ b/edge.go
@@ -37,7 +37,7 @@ func (e *Edge) Validate() error {
 	return nil
 }
 
-func NewEdge(from, to *Node, fromSide, toSide string) *Edge {
+func NewEdge(from, to Node, fromSide, toSide string) Edge {
 	e := Edge{
 		ID:       util.NewID(),
 		FromNode: from.ID,
@@ -45,5 +45,5 @@ func NewEdge(from, to *Node, fromSide, toSide string) *Edge {
 		ToNode:   to.ID,
 		ToSide:   &toSide,
 	}
-	return &e
+	return e
 }


### PR DESCRIPTION
- Adds `ChildNodes` and `ParentNodes` methods to the `Canvas` module
